### PR TITLE
Bump tap-mysql version to 1.17.5 - #175361674

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mysql',
-      version='1.15.1',
+      version='1.17.5',
       description='Singer.io tap for extracting data from MySQL',
       author='Stitch',
       url='https://singer.io',
@@ -12,10 +12,10 @@ setup(name='tap-mysql',
       install_requires=[
           'attrs==16.3.0',
           'pendulum==1.2.0',
-          'singer-python==5.5.0',
-          'PyMySQL==0.7.11',
-          'backoff==1.3.2',
-          'mysql-replication==0.18',
+          'singer-python==5.9.0',
+          'PyMySQL==0.9.3',
+          'backoff==1.8.0',
+          'mysql-replication==0.22',
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
# Description of change
Upgrade tap-mysql to 1.17.5 version - https://www.pivotaltracker.com/story/show/175361674


# QA steps
NA
 
# Risks
Extraction process might get impacted


# Rollback steps
 - revert this branch
